### PR TITLE
refactor: removing some code & comments, adding other comments

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,32 +29,37 @@ variable "resource_group_name" {
   description = "Eventhub name to use for function"
 }
 
-variable "azure_tenant_id" {
-  type        = string
-  description = "Eventhub name to use for function"
-}
+# To be used if "az login" and "azuread_client_config" not used 
 
-variable "azure_client_id" {
-  type        = string
-  description = "Eventhub name to use for function"
-}
+# variable "azure_tenant_id" {
+#   type        = string
+#   description = "Eventhub name to use for function"
+# }
 
-variable "azure_client_secret" {
-  type        = string
-  description = "Eventhub name to use for function"
-}
+# variable "azure_client_id" {
+#   type        = string
+#   description = "Eventhub name to use for function"
+# }
+
+# variable "azure_client_secret" {
+#   type        = string
+#   description = "Eventhub name to use for function"
+# }
 
 variable "timer_func_schedule" {
   type        = string
   description = "Eventhub name to use for function"
+  default     = "0 */1 * * * *"
 }
 
 variable "timer_func_schedule_vm" {
   type        = string
   description = "Eventhub name to use for function"
+  default     = "30 */1 * * * *"
 }
 
 variable "location" {
   type        = string
   description = "Eventhub name to use for function"
+  default     = "East US"
 }


### PR DESCRIPTION
- Added comments to [main.tf](http://main.tf/) explaining purpose of terraform objects

- Commented out azure environmental configs in [variables.tf](http://variables.tf/) BUT left them in case users would rather employ those instead of using az login and terraform data azuread_client_config

- Added default values to timer_func_schedule, timer_func_schedule_vm, and location

- Removed other commented out terraform previously required to push and utilize the ObserveFunction App

- NOTE: [Azure Functions Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools) must be installed locally