### PR TITLE
fix: remove app insights until provider bug is fixed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,8 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
     timer_vm_metrics_func_schedule = var.timer_vm_metrics_func_schedule
     EVENTHUB_TRIGGER_FUNCTION_EVENTHUB_NAME = azurerm_eventhub.observe_eventhub.name 
     EVENTHUB_TRIGGER_FUNCTION_EVENTHUB_CONNECTION = "${azurerm_eventhub_authorization_rule.observe_eventhub_access_policy.primary_connection_string}"
-    APPINSIGHTS_INSTRUMENTATIONKEY = azurerm_application_insights.observe_insights.instrumentation_key
+    # Pending resolution of https://github.com/hashicorp/terraform-provider-azurerm/issues/18026
+    # APPINSIGHTS_INSTRUMENTATIONKEY = azurerm_application_insights.observe_insights.instrumentation_key 
   }
 
   site_config {
@@ -127,12 +128,13 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
   }
 }
 
-resource "azurerm_application_insights" "observe_insights" {
-  name                = "observeApplicationInsights"
-  location            = azurerm_resource_group.observe_resource_group.location
-  resource_group_name = azurerm_resource_group.observe_resource_group.name
-  application_type    = "web"
-}
+# Pending resolution of https://github.com/hashicorp/terraform-provider-azurerm/issues/18026
+# resource "azurerm_application_insights" "observe_insights" {
+#   name                = "observeApplicationInsights"
+#   location            = azurerm_resource_group.observe_resource_group.location
+#   resource_group_name = azurerm_resource_group.observe_resource_group.name
+#   application_type    = "web"
+# }
 
 resource "null_resource" "function_app_publish" {
   provisioner "local-exec" {


### PR DESCRIPTION
Application Insights creates smart detection rules that Terraform doesn't manage.  This causes breakage when we attempt to destroy our collection.  Commented it out for now until Microsoft resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/18026