### PR TITLE
feat: use key vault to store observe token

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -3,7 +3,7 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       #version = "=3.0.0"
-      version = "~> 3.0"
+      version = ">=3.0.0"
     }
   }
 }


### PR DESCRIPTION
Uses the key vault to store the observe customer token instead of storing in plain text in the observe function app.  The environment variable has to be hardcoded the way it's done here because if we try to use the output from the terraform var, we get a circular dependency.  The token URL follows a standard format so we are able to use the hardcoded variable.