### PR TITLE
fix: unique resource IDs for policy definitions

### DIFF
--- a/ObserveFunctionApp/local.settings.json
+++ b/ObserveFunctionApp/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "AzureWebJobsStorage": ""
+    }
+}

--- a/collection/main.tf
+++ b/collection/main.tf
@@ -1,23 +1,23 @@
 # NOTE: Azure Functions Core Tools must be installed locally
 # https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools
 locals {
-    is_windows = substr(pathexpand("~"), 0, 1) == "/" ? false : true
-    sleep_command = local.is_windows == true ? "Start-Sleep" : "sleep"
-    region = lookup(var.location_abbreviation, var.location, "none-found")
-    keyvault_name = "${local.region}${var.observe_customer}${local.sub}"
-    sub = substr(data.azurerm_subscription.primary.subscription_id, -8, -1)
+  is_windows    = substr(pathexpand("~"), 0, 1) == "/" ? false : true
+  sleep_command = local.is_windows == true ? "Start-Sleep" : "sleep"
+  region        = lookup(var.location_abbreviation, var.location, "none-found")
+  keyvault_name = "${local.region}${var.observe_customer}${local.sub}"
+  sub           = substr(data.azurerm_subscription.primary.subscription_id, -8, -1)
 }
 
 # Obtains current client config from az login, allowing terraform to run.
-data "azuread_client_config" "current" { }
+data "azuread_client_config" "current" {}
 
 # Creates the alias of your Subscription to be used for association below.
-data "azurerm_subscription" "primary" { }
+data "azurerm_subscription" "primary" {}
 
 # https://petri.com/understanding-azure-app-registrations/#:~:text=Azure%20App%20registrations%20are%20an,to%20use%20an%20app%20registration.
 resource "azuread_application" "observe_app_registration" {
   display_name = "observeApp-${var.observe_customer}-${var.location}-${local.sub}"
-  owners = [data.azuread_client_config.current.object_id]
+  owners       = [data.azuread_client_config.current.object_id]
 }
 
 # Creates an auth token that is used by the app to call APIs.
@@ -31,10 +31,10 @@ resource "azuread_service_principal" "observe_service_principal" {
 }
 
 resource "azurerm_key_vault" "key_vault" {
-  name                        = "${local.keyvault_name}"
-  location                    = var.location
-  resource_group_name         = azurerm_resource_group.observe_resource_group.name
-  tenant_id                   = data.azuread_client_config.current.tenant_id
+  name                = local.keyvault_name
+  location            = var.location
+  resource_group_name = azurerm_resource_group.observe_resource_group.name
+  tenant_id           = data.azuread_client_config.current.tenant_id
 
   sku_name = "standard"
 
@@ -56,7 +56,7 @@ resource "azurerm_key_vault" "key_vault" {
 
   access_policy {
     tenant_id = data.azuread_client_config.current.tenant_id
-    object_id =lookup(azurerm_linux_function_app.observe_collect_function_app.identity[0],"principal_id")
+    object_id = lookup(azurerm_linux_function_app.observe_collect_function_app.identity[0], "principal_id")
 
     secret_permissions = [
       "Backup",
@@ -113,8 +113,8 @@ resource "azurerm_eventhub" "observe_eventhub" {
 }
 
 resource "azurerm_eventhub_namespace_authorization_rule" "observe_eventhub_access_policy" {
-  name                = "observeSharedAccessPolicy-${var.observe_customer}-${var.location}-${local.sub}"
-  namespace_name      = azurerm_eventhub_namespace.observe_eventhub_namespace.name
+  name           = "observeSharedAccessPolicy-${var.observe_customer}-${var.location}-${local.sub}"
+  namespace_name = azurerm_eventhub_namespace.observe_eventhub_namespace.name
   # eventhub_name       = azurerm_eventhub.observe_eventhub.name
   resource_group_name = azurerm_resource_group.observe_resource_group.name
   listen              = true
@@ -164,17 +164,17 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
   storage_account_access_key = azurerm_storage_account.observe_storage_account.primary_access_key
 
   app_settings = {
-    AzureWebJobsDisableHomepage = true
-    OBSERVE_DOMAIN = var.observe_domain
-    OBSERVE_CUSTOMER = var.observe_customer
-    OBSERVE_TOKEN = "@Microsoft.KeyVault(SecretUri=https://${local.keyvault_name}.vault.azure.net/secrets/observe-token/)"
-    AZURE_TENANT_ID = data.azuread_client_config.current.tenant_id
-    AZURE_CLIENT_ID = azuread_application.observe_app_registration.application_id
-    AZURE_CLIENT_SECRET = azuread_application_password.observe_password.value
-    AZURE_CLIENT_LOCATION = lower(replace(var.location, " ", ""))
-    timer_resources_func_schedule = var.timer_resources_func_schedule
-    timer_vm_metrics_func_schedule = var.timer_vm_metrics_func_schedule
-    EVENTHUB_TRIGGER_FUNCTION_EVENTHUB_NAME = azurerm_eventhub.observe_eventhub.name 
+    AzureWebJobsDisableHomepage                   = true
+    OBSERVE_DOMAIN                                = var.observe_domain
+    OBSERVE_CUSTOMER                              = var.observe_customer
+    OBSERVE_TOKEN                                 = "@Microsoft.KeyVault(SecretUri=https://${local.keyvault_name}.vault.azure.net/secrets/observe-token/)"
+    AZURE_TENANT_ID                               = data.azuread_client_config.current.tenant_id
+    AZURE_CLIENT_ID                               = azuread_application.observe_app_registration.application_id
+    AZURE_CLIENT_SECRET                           = azuread_application_password.observe_password.value
+    AZURE_CLIENT_LOCATION                         = lower(replace(var.location, " ", ""))
+    timer_resources_func_schedule                 = var.timer_resources_func_schedule
+    timer_vm_metrics_func_schedule                = var.timer_vm_metrics_func_schedule
+    EVENTHUB_TRIGGER_FUNCTION_EVENTHUB_NAME       = azurerm_eventhub.observe_eventhub.name
     EVENTHUB_TRIGGER_FUNCTION_EVENTHUB_CONNECTION = "${azurerm_eventhub_authorization_rule.observe_eventhub_access_policy.primary_connection_string}"
     # Pending resolution of https://github.com/hashicorp/terraform-provider-azurerm/issues/18026
     # APPINSIGHTS_INSTRUMENTATIONKEY = azurerm_application_insights.observe_insights.instrumentation_key 
@@ -185,9 +185,9 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
   }
 
   site_config {
-      application_stack  {
-        python_version = "3.9"
-      }
+    application_stack {
+      python_version = "3.9"
+    }
   }
 }
 
@@ -202,7 +202,7 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
 resource "null_resource" "function_app_publish" {
   provisioner "local-exec" {
     interpreter = local.is_windows ? ["PowerShell", "-Command"] : []
-    command = <<EOT
+    command     = <<EOT
       ${local.sleep_command} 30
       cd ${path.module}/ObserveFunctionApp
       func azure functionapp publish ${azurerm_linux_function_app.observe_collect_function_app.name} --python
@@ -215,7 +215,7 @@ resource "null_resource" "function_app_publish" {
 }
 
 output "eventhubs" {
-  value  = azurerm_eventhub.observe_eventhub
+  value = azurerm_eventhub.observe_eventhub
 }
 
 output "eventhub_keys" {

--- a/collection/variables.tf
+++ b/collection/variables.tf
@@ -11,7 +11,7 @@ variable "observe_token" {
 variable "observe_domain" {
   type        = string
   description = "Observe domain"
-  default = "observeinc.com"
+  default     = "observeinc.com"
 }
 
 # Based on NCRONTAB Expressions
@@ -40,7 +40,7 @@ variable "location" {
 variable "location_abbreviation" {
   type        = map(string)
   description = "A unique, short abbreviation to use for each location when assiging names to resources"
-  default     = {
+  default = {
     "australiacentral" : "ac",
     "australiacentral2" : "ac2",
     "australiaeast" : "ae",

--- a/initiative_definition/main.tf
+++ b/initiative_definition/main.tf
@@ -1,10 +1,10 @@
-data "azurerm_subscription" "primary" { }
+data "azurerm_subscription" "primary" {}
 
 resource "azurerm_management_group_policy_assignment" "observe_policy_assignment" {
   name                 = "observe-policy-${var.location}"
   policy_definition_id = var.policy_set
   management_group_id  = var.management_group_id
-  location = var.location
+  location             = var.location
 
   identity {
     type = "SystemAssigned"

--- a/initiative_definition/variables.tf
+++ b/initiative_definition/variables.tf
@@ -1,5 +1,5 @@
 variable "location" {
-    type = string  
+  type = string
 }
 
 variable "eventhub" {
@@ -11,7 +11,7 @@ variable "eventhub_key" {
 }
 
 variable "management_group_id" {
-    type = string
+  type = string
 }
 
 variable "policy_set" {

--- a/main.tf
+++ b/main.tf
@@ -1,28 +1,28 @@
 module "collection" {
-    for_each = toset(var.location)
-    source = "./collection"
+  for_each = toset(var.location)
+  source   = "./collection"
 
-    observe_customer = var.observe_customer
-    observe_token = var.observe_token
-    observe_domain = var.observe_domain
-    timer_resources_func_schedule = var.timer_resources_func_schedule
-    timer_vm_metrics_func_schedule = var.timer_vm_metrics_func_schedule
-    location = each.value
-  
+  observe_customer               = var.observe_customer
+  observe_token                  = var.observe_token
+  observe_domain                 = var.observe_domain
+  timer_resources_func_schedule  = var.timer_resources_func_schedule
+  timer_vm_metrics_func_schedule = var.timer_vm_metrics_func_schedule
+  location                       = each.value
+
 
 }
 module "policy" {
-    source = "./policy_definition"
+  source = "./policy_definition"
 }
 
 module "policy_assignment" {
-    source = "./initiative_definition"
+  source = "./initiative_definition"
 
-    for_each = toset(var.location)
+  for_each = toset(var.location)
 
-    location = each.value
-    management_group_id = module.policy.management_group.id
-    policy_set = module.policy.policy_set
-    eventhub = module.collection[each.key].eventhubs.id
-    eventhub_key = "${trimsuffix(module.collection[each.key].eventhub_keys.id, element(split("/",module.collection[each.key].eventhub_keys.id), length(split("/", module.collection[each.key].eventhub_keys.id))-1))}rootmanagesharedaccesskey"
+  location            = each.value
+  management_group_id = module.policy.management_group.id
+  policy_set          = module.policy.policy_set
+  eventhub            = module.collection[each.key].eventhubs.id
+  eventhub_key        = "${trimsuffix(module.collection[each.key].eventhub_keys.id, element(split("/", module.collection[each.key].eventhub_keys.id), length(split("/", module.collection[each.key].eventhub_keys.id)) - 1))}rootmanagesharedaccesskey"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,12 +1,12 @@
 provider "azurerm" {
-     features {}
+  features {}
 }
 
-terraform { 
- required_providers { 
-     azurerm = { 
-         source = "hashicorp/azurerm"
-         version = ">= 3.0.0" 
-     } 
- } 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0.0"
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "observe_token" {
 variable "observe_domain" {
   type        = string
   description = "Observe domain"
-  default = "observeinc.com"
+  default     = "observeinc.com"
 }
 
 # Based on NCRONTAB Expressions
@@ -40,7 +40,7 @@ variable "location" {
 variable "location_abbreviation" {
   type        = map(string)
   description = "A unique, short abbreviation to use for each location when assiging names to resources"
-  default     = {
+  default = {
     "australiacentral" : "ac",
     "australiacentral2" : "ac2",
     "australiaeast" : "ae",


### PR DESCRIPTION
Augmented @yasar-observe's policy and initiative creation work to ensure the policy definitions are all created with unique resource IDs.

Was able to completely terraform apply then destroy.