### PR TITLE
feat: bump collection version so we collect vmss and vmssvm

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "timer_vm_metrics_func_schedule" {
 variable "func_url" {
   type        = string
   description = "Observe Collect Function source URL zip"
-  default     = "https://observeinc.s3.us-west-2.amazonaws.com/azure/azure-collection-functions-v0.3.0.zip"
+  default     = "https://observeinc.s3.us-west-2.amazonaws.com/azure/azure-collection-functions-v0.4.0.zip"
 }
 
 # Use Name for value


### PR DESCRIPTION
This bumps the version of our function collection to now include collecting Virtual Machine Scale Sets and Virtual Machine Scale Set VM metadata to support linking to Kubernetes Nodes from AKS.