### PR TITLE
feat: bump collection version to collect VMSS to link to k8s app

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "timer_vm_metrics_func_schedule" {
 variable "func_url" {
   type        = string
   description = "Observe Collect Function source URL zip"
-  default     = "https://observeinc.s3.us-west-2.amazonaws.com/azure/azure-collection-functions-v0.4.0.zip"
+  default     = "https://observeinc.s3.us-west-2.amazonaws.com/azure/azure-collection-functions-v0.6.0.zip"
 }
 
 # Use Name for value


### PR DESCRIPTION
We need VMSS to link K8s nodes to AKS.  This collects the VMSS and the VMSS VM metrics to support the VMSS VM dashboard as well.