### PR TITLE
feat: add outputs for eventhub namespace id and eventhub name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "eventhub_name" {
+    description = "Eventhub name used for Observe collection."
+    value = azurerm_eventhub.observe_eventhub.name
+}
+
+output "eventhub_namespace_id" {
+    description = "Resource ID of the eventhub namespace used for Observe collection."
+    value = azurerm_eventhub_namespace.observe_eventhub_namespace.id
+}


### PR DESCRIPTION
Adding this makes it easier to pass the values to other terraform modules if you want to automate diagnostic setting creation.