### PR TITLE
feat: add var to allow deletion of non-empty resource groups

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -10,5 +10,9 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {}
+   features {
+     resource_group {
+       prevent_deletion_if_contains_resources = var.prevent_rg_deletion
+     }
+   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,9 @@ variable "location_abbreviation" {
     "westusstage" : "wus",
   }
 }
+
+variable "prevent_rg_deletion" {
+  type = bool
+  default = true
+  description = "Prevent resource group deletion if resource group is not empty.  Defaults to true."
+}


### PR DESCRIPTION
By default, terraform refuses to delete non-empty resource groups when destroying. If you create application insights in the resource group, Azure will create non-terraform controlled resources in your resource group so it will usually fail when you go to destroy.  This is the desired behavior in most cases but adding the var allows users who want to override this functionality to do so.