### PR TITLE
fix: key vault was getting created before function app

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,44 +37,51 @@ resource "azurerm_key_vault" "key_vault" {
   tenant_id           = data.azuread_client_config.current.tenant_id
 
   sku_name = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "user" {
+  key_vault_id = azurerm_key_vault.key_vault.id
+  tenant_id    = data.azuread_client_config.current.tenant_id
+  object_id    = data.azuread_client_config.current.object_id
 
 
-  access_policy {
-    tenant_id = data.azuread_client_config.current.tenant_id
-    object_id = data.azuread_client_config.current.object_id
+  secret_permissions = [
+    "Backup",
+    "Restore",
+    "Get",
+    "Set",
+    "List",
+    "Delete",
+    "Purge",
+  ]
+}
 
-    secret_permissions = [
-      "Backup",
-      "Restore",
-      "Get",
-      "Set",
-      "List",
-      "Delete",
-      "Purge",
-    ]
-  }
+resource "azurerm_key_vault_access_policy" "app" {
+  key_vault_id = azurerm_key_vault.key_vault.id
+  tenant_id    = data.azuread_client_config.current.tenant_id
+  object_id    = lookup(azurerm_linux_function_app.observe_collect_function_app.identity[0], "principal_id")
 
-  access_policy {
-    tenant_id = data.azuread_client_config.current.tenant_id
-    object_id = lookup(azurerm_linux_function_app.observe_collect_function_app.identity[0], "principal_id")
 
-    secret_permissions = [
-      "Backup",
-      "Restore",
-      "Get",
-      "Set",
-      "List",
-      "Delete",
-      "Purge",
-    ]
-  }
-
+  secret_permissions = [
+    "Backup",
+    "Restore",
+    "Get",
+    "Set",
+    "List",
+    "Delete",
+    "Purge",
+  ]
 }
 
 resource "azurerm_key_vault_secret" "observe_token" {
   name         = "observe-token"
   value        = var.observe_token
   key_vault_id = azurerm_key_vault.key_vault.id
+
+  # Required so the user running this can get the result of the call.
+  depends_on = [
+    azurerm_key_vault_access_policy.user,
+  ]
 }
 
 # Assigns the created service principal a role in current Azure Subscription.
@@ -158,7 +165,7 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
     AzureWebJobsDisableHomepage                   = true
     OBSERVE_DOMAIN                                = var.observe_domain
     OBSERVE_CUSTOMER                              = var.observe_customer
-    OBSERVE_TOKEN                                 = "@Microsoft.KeyVault(SecretUri=https://${local.keyvault_name}.vault.azure.net/secrets/observe-token/)"
+    OBSERVE_TOKEN                                 = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.observe_token.id})"
     AZURE_TENANT_ID                               = data.azuread_client_config.current.tenant_id
     AZURE_CLIENT_ID                               = azuread_application.observe_app_registration.application_id
     AZURE_CLIENT_SECRET                           = azuread_application_password.observe_password.value

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "eventhub_name" {
-    description = "Eventhub name used for Observe collection."
-    value = azurerm_eventhub.observe_eventhub.name
+  description = "Eventhub name used for Observe collection."
+  value       = azurerm_eventhub.observe_eventhub.name
 }
 
 output "eventhub_namespace_id" {
-    description = "Resource ID of the eventhub namespace used for Observe collection."
-    value = azurerm_eventhub_namespace.observe_eventhub_namespace.id
+  description = "Resource ID of the eventhub namespace used for Observe collection."
+  value       = azurerm_eventhub_namespace.observe_eventhub_namespace.id
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      #version = "=3.0.0"
+      source = "hashicorp/azurerm"
       version = ">=3.0.0"
     }
   }
@@ -10,9 +9,9 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-   features {
-     resource_group {
-       prevent_deletion_if_contains_resources = var.prevent_rg_deletion
-     }
-   }
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = var.prevent_rg_deletion
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -130,7 +130,7 @@ variable "location_abbreviation" {
 }
 
 variable "prevent_rg_deletion" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Prevent resource group deletion if resource group is not empty.  Defaults to true."
 }


### PR DESCRIPTION
Fixes a bug where the Azure Key Vault would get created after the function app requiring either ~15 minutes for data to flow or a restart of the function app to get it sooner.  Breaking out the access policies fixes the dependency chain so that everything gets created in the proper order and collection begins sooner.