### PR TITLE
chore: add fixed-env CI workflow for TF plan-apply

### DIFF
--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -1,8 +1,11 @@
 import json
 import os
 import re 
+from dotenv import load_dotenv
+load_dotenv()
 
 
+print(os.environ)
 
 # Extract branch name from either GITHUB_HEAD_REF or GITHUB_REF
 branch = os.getenv("GITHUB_HEAD_REF")

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -62,12 +62,12 @@ config = {
         },
          "azurerm_key_vault": {
             "key_vault": {
-                "name": "gh-kv-" + branch
+                "name": "gh-kv-" + branch_concat
             }
         },
          "azurerm_eventhub_namespace": {
             "observe_eventhub_namespace": {
-                "name": "gh-ehns-" + branch
+                "name": "gh-ehns-" + branch_concat
             }
         },
          "azurerm_eventhub": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -7,6 +7,9 @@ load_dotenv()
 
 print(os.environ)
 
+print(  os.getenv("GITHUB_HEAD_REF"))
+print(  os.getenv("GITHUB_REF"))
+
 # Extract branch name from either GITHUB_HEAD_REF or GITHUB_REF
 branch = os.getenv("GITHUB_HEAD_REF")
 if branch is None:

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -75,7 +75,10 @@ config = {
         },
          "azurerm_eventhub_namespace": {
             "observe_eventhub_namespace": {
-                "name": "gh-ehns-" + branch_concat
+                "name": "gh-ehns-" + branch_concat,
+                 "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
          "azurerm_eventhub": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -57,9 +57,21 @@ config = {
         },
          "azurerm_key_vault": {
             "key_vault": {
-                "name": "gh-kv-" + branch_concat
+                "name": "gh-kv-" + branch
+            }
+        },
+         "azurerm_eventhub_namespace": {
+            "observe_eventhub_namespace": {
+                "name": "gh-ehns-" + branch
+            }
+        },
+         "azurerm_eventhub": {
+            "observe_eventhub": {
+                "name": "gh-eh-" + branch
             }
         }
+
+        
     }
 }
 

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -54,6 +54,11 @@ config = {
             "observe_storage_account": {
                 "name": "ghsa" + branch_concat
             }
+        },
+         "azurerm_key_vault": {
+            "key_vault": {
+                "name": "gh-kv-" + branch_concat
+            }
         }
     }
 }

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -74,8 +74,23 @@ config = {
             "observe_eventhub": {
                 "name": "gh-eh-" + branch
             }
-        }
+        },
+         "azurerm_eventhub_authorization_rule": {
+            "observe_eventhub_access_policy": {
+                "name": "gh-ehap-" + branch
+            }
+        },
+        "azurerm_service_plan": {
+            "observe_service_plan": {
+                "name": "gh-sp-" + branch
+            }
+        },
 
+        "azurerm_linux_function_app": {
+            "observe_collect_function_app": {
+                "name": "gh-fa-" + branch
+            }
+        }
         
     }
 }

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -39,7 +39,10 @@ config = {
     "resource": {
         "azurerm_resource_group": {
             "observe_resource_group": {
-                "name": "gh-rg-" + branch
+                "name": "gh-rg-" + branch,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
         "azuread_application": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -39,7 +39,7 @@ config = {
     "resource": {
         "azurerm_resource_group": {
             "observe_resource_group": {
-                "name": "gh-rg" + branch
+                "name": "gh-rg-" + branch
             }
         },
         "azuread_application": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -7,7 +7,7 @@ print( "GITHUB_HEAD_REF: " + os.getenv("GITHUB_HEAD_REF"))
 print( "GITHUB_REF: " + os.getenv("GITHUB_REF"))
 
 # Extract branch name from either GITHUB_HEAD_REF or GITHUB_REF
-if os.getenv("GITHUB_HEAD_REF") is not None and os.getenv("GITHUB_HEAD_REF") is not '':
+if os.getenv("GITHUB_HEAD_REF") is not None and os.getenv("GITHUB_HEAD_REF") != '':
     branch = os.getenv("GITHUB_HEAD_REF")
 else:
     branch = os.getenv("GITHUB_REF")

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -3,8 +3,8 @@ import os
 import re 
 
 
-print(  os.getenv("GITHUB_HEAD_REF"))
-print(  os.getenv("GITHUB_REF"))
+print( "GITHUB_HEAD_REF: " + os.getenv("GITHUB_HEAD_REF"))
+print( "GITHUB_REF: " + os.getenv("GITHUB_REF"))
 
 # Extract branch name from either GITHUB_HEAD_REF or GITHUB_REF
 branch = os.getenv("GITHUB_HEAD_REF")

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -1,0 +1,80 @@
+import json
+import os
+import re 
+
+
+
+# Extract branch name from either GITHUB_HEAD_REF or GITHUB_REF
+branch = os.getenv("GITHUB_HEAD_REF")
+if branch is None:
+    branch = os.getenv("GITHUB_REF", "")
+branch = branch.replace("refs/heads/", "")
+
+# Replace "/" with "-" in the branch name
+branch = branch.replace("/", "-")
+
+
+# Append the modified branch name to GITHUB_OUTPUT
+if os.getenv("CI"):
+    with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
+        f.write(f"branch={branch}\n")
+
+# Convert branch name to lowercase, remove special characters, and save to branch_concat
+# Remove special characters
+branch_remove_special = re.sub(r"[/\-]", "", branch)
+# Convert to lowercase
+branch_lowercase = branch_remove_special.lower()
+# Concatenate to 20 characters
+branch_concat = branch_lowercase[:20]
+
+# Append the concat branch name to GITHUB_OUTPUT
+if os.getenv("CI"):
+    with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
+        f.write(f"branch_concat={branch_concat}\n")
+
+print (f"Branch name: {branch}")
+print (f"Branch name concat: {branch_concat}")
+
+
+
+# Define the JSON structure
+config = {
+    "terraform": {
+        "backend": {
+            "azurerm": {}
+        }
+    },
+    "resource": {
+        "azurerm_resource_group": {
+            "observe_resource_group": {
+                "name": "gh-rg" + branch
+            }
+        },
+        "azuread_application": {
+            "observe_app_registration": {
+                "display_name":  "gh-app-" + branch
+            }
+        },
+        "azurerm_storage_account": {
+            "observe_storage_account": {
+                "name": "ghsa" + branch_concat
+            }
+        }
+    }
+}
+
+
+# Write the JSON to file
+with open("override.tf.json", "w") as json_file:
+    print ("Writing override.tf.json.....")
+    json.dump(config, json_file, indent=3)
+
+
+# Open the JSON file
+with open("override.tf.json", "r") as json_file:
+    # Load the JSON data
+    data = json.load(json_file)
+
+# Print the contents of the JSON file
+print ("Contents of override.tf.json")
+print(json.dumps(data, indent=4))

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -23,7 +23,7 @@ branch = branch.replace("refs/heads/", "").replace("/", "-")
 
 # Convert branch name to lowercase, remove special characters, and save to branch_concat
 # Remove special characters
-branch_concat = re.sub(r"[/\-]", "", branch).lower()[:20]
+branch_concat = re.sub(r"[/\-]", "", branch).lower()[:20] #Max 20 characters for branch name 
 
 
 

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -13,6 +13,8 @@ else:
     branch = os.getenv("GITHUB_REF")
 
 
+
+
 # Remove /refs/heads/ from the branch name
 # Replace "/" with "-" in the branch name
 # Example: refs/heads/nikhil/add-CI-OB-29418 becomes nikhil-add-CI-OB-29418
@@ -29,7 +31,19 @@ print (f"Branch name: {branch}")
 print (f"Branch name concat: {branch_concat}")
 
 
+rg_name = "gh-rg-" + branch
+app_name = "gh-app-" + branch
+storage_account_name = "ghsa" + branch_concat #Max 24 characters no capital letters,dash, underscore
+key_vault_name = "ghkv" + branch_concat #Max 24 characters, no underscores/capital letters 
+eventhub_namespace_name = "gh-ehns-" + branch
+eventhub_name = "gh-eh-" + branch
+eventhub_access_policy_name = "gh-ehap-" + branch
+service_plan_name = "gh-sp-" + branch
+function_app_name = "gh-fa-" + branch
+
+
 # Define the JSON structure
+## See https://learn.microsoft.com/en-us/answers/questions/1437283/azure-policy-issue
 config = {
     "terraform": {
         "backend": {
@@ -44,73 +58,81 @@ config = {
     "resource": {
         "azurerm_resource_group": {
             "observe_resource_group": {
-                "name": "gh-rg-" + branch,
+                "name": rg_name,
                 "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci",
+                    "branch": branch
                 }
             }
         },
         "azuread_application": {
             "observe_app_registration": {
-                "display_name":  "gh-app-" + branch,
-                "tags": ["terraform-ci"]                  
+                "display_name":  app_name,
+                "tags": ["terraform-ci", branch]                  
                 
             }
         },
         "azurerm_storage_account": {
             "observe_storage_account": {
-                "name": "ghsa" + branch_concat,
+                "name":  storage_account_name,
                 "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci",
+                    "branch": branch
                 }
             }
         },
          "azurerm_key_vault": {
             "key_vault": {
-                "name": "gh-kv-" + branch_concat,
+                "name": key_vault_name,
                 "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci",
+                    "branch": branch
                 }
             }
         },
          "azurerm_eventhub_namespace": {
             "observe_eventhub_namespace": {
-                "name": "gh-ehns-" + branch_concat,
+                "name": eventhub_namespace_name,
                  "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci",
+                    "branch": branch
                 }
             }
         },
          "azurerm_eventhub": {
             "observe_eventhub": {
-                "name": "gh-eh-" + branch,
+                "name": eventhub_name,
                 "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci",
+                    "branch": branch
                 }
             }
         },
          "azurerm_eventhub_authorization_rule": {
             "observe_eventhub_access_policy": {
-                "name": "gh-ehap-" + branch,
+                "name": eventhub_access_policy_name,
                 "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci",
+                    "branch": branch
                 }
             }
         },
         "azurerm_service_plan": {
             "observe_service_plan": {
-                "name": "gh-sp-" + branch,
+                "name": service_plan_name,
                 "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci", 
+                    "branch": branch
                 }
             }
         },
 
         "azurerm_linux_function_app": {
             "observe_collect_function_app": {
-                "name": "gh-fa-" + branch,
+                "name": function_app_name,
                 "tags": {
-                    "created_by": "terraform-ci"
+                    "created_by": "terraform-ci",
+                    "branch": branch
                 }
             }
         }

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -33,7 +33,12 @@ print (f"Branch name concat: {branch_concat}")
 config = {
     "terraform": {
         "backend": {
-            "azurerm": {}
+            "azurerm": {
+                "resource_group_name": "rg-terraform-github-actions-state",
+                "storage_account_name": "citeststfazurecollection",
+                "container_name": "tfstate",
+                "key": branch + "/.tfstate"
+            }
         }
     },
     "resource": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -53,7 +53,13 @@ config = {
                 "container_name": "tfstate",
                 "key": branch + "/.tfstate"
             }
-        }
+        },
+        "required_providers": {
+        "observe": {
+            "source": "terraform.observeinc.com/observeinc/observe",
+            "version": ">= 0.13.3"
+            }
+        },               
     },
     "resource": {
         "azurerm_resource_group": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -53,9 +53,8 @@ config = {
         "azuread_application": {
             "observe_app_registration": {
                 "display_name":  "gh-app-" + branch,
-                "tags": {
-                    "created_by": "terraform-ci"
-                }
+                "tags": ["terraform-ci"]                  
+                
             }
         },
         "azurerm_storage_account": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -53,13 +53,7 @@ config = {
                 "container_name": "tfstate",
                 "key": branch + "/.tfstate"
             }
-        },
-        "required_providers": {
-        "observe": {
-            "source": "terraform.observeinc.com/observeinc/observe",
-            "version": ">= 0.13.3"
-            }
-        },               
+        },                      
     },
     "resource": {
         "azurerm_resource_group": {

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -1,11 +1,7 @@
 import json
 import os
 import re 
-from dotenv import load_dotenv
-load_dotenv()
 
-
-print(os.environ)
 
 print(  os.getenv("GITHUB_HEAD_REF"))
 print(  os.getenv("GITHUB_REF"))

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -52,17 +52,26 @@ config = {
         },
         "azuread_application": {
             "observe_app_registration": {
-                "display_name":  "gh-app-" + branch
+                "display_name":  "gh-app-" + branch,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
         "azurerm_storage_account": {
             "observe_storage_account": {
-                "name": "ghsa" + branch_concat
+                "name": "ghsa" + branch_concat,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
          "azurerm_key_vault": {
             "key_vault": {
-                "name": "gh-kv-" + branch_concat
+                "name": "gh-kv-" + branch_concat,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
          "azurerm_eventhub_namespace": {
@@ -72,23 +81,35 @@ config = {
         },
          "azurerm_eventhub": {
             "observe_eventhub": {
-                "name": "gh-eh-" + branch
+                "name": "gh-eh-" + branch,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
          "azurerm_eventhub_authorization_rule": {
             "observe_eventhub_access_policy": {
-                "name": "gh-ehap-" + branch
+                "name": "gh-ehap-" + branch,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
         "azurerm_service_plan": {
             "observe_service_plan": {
-                "name": "gh-sp-" + branch
+                "name": "gh-sp-" + branch,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         },
 
         "azurerm_linux_function_app": {
             "observe_collect_function_app": {
-                "name": "gh-fa-" + branch
+                "name": "gh-fa-" + branch,
+                "tags": {
+                    "created_by": "terraform-ci"
+                }
             }
         }
         

--- a/.github/scripts/create_override.py
+++ b/.github/scripts/create_override.py
@@ -7,36 +7,26 @@ print( "GITHUB_HEAD_REF: " + os.getenv("GITHUB_HEAD_REF"))
 print( "GITHUB_REF: " + os.getenv("GITHUB_REF"))
 
 # Extract branch name from either GITHUB_HEAD_REF or GITHUB_REF
-branch = os.getenv("GITHUB_HEAD_REF")
-if branch is None:
-    branch = os.getenv("GITHUB_REF", "")
-branch = branch.replace("refs/heads/", "")
+if os.getenv("GITHUB_HEAD_REF") is not None and os.getenv("GITHUB_HEAD_REF") is not '':
+    branch = os.getenv("GITHUB_HEAD_REF")
+else:
+    branch = os.getenv("GITHUB_REF")
 
+
+# Remove /refs/heads/ from the branch name
 # Replace "/" with "-" in the branch name
-branch = branch.replace("/", "-")
+# Example: refs/heads/nikhil/add-CI-OB-29418 becomes nikhil-add-CI-OB-29418
+branch = branch.replace("refs/heads/", "").replace("/", "-")
 
-
-# Append the modified branch name to GITHUB_OUTPUT
-if os.getenv("CI"):
-    with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
-        f.write(f"branch={branch}\n")
 
 # Convert branch name to lowercase, remove special characters, and save to branch_concat
 # Remove special characters
-branch_remove_special = re.sub(r"[/\-]", "", branch)
-# Convert to lowercase
-branch_lowercase = branch_remove_special.lower()
-# Concatenate to 20 characters
-branch_concat = branch_lowercase[:20]
+branch_concat = re.sub(r"[/\-]", "", branch).lower()[:20]
 
-# Append the concat branch name to GITHUB_OUTPUT
-if os.getenv("CI"):
-    with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
-        f.write(f"branch_concat={branch_concat}\n")
+
 
 print (f"Branch name: {branch}")
 print (f"Branch name concat: {branch_concat}")
-
 
 
 # Define the JSON structure

--- a/.github/scripts/observe.tf
+++ b/.github/scripts/observe.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    observe = {
+      source  = "terraform.observeinc.com/observeinc/observe"
+      version = ">= 0.13.3"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
 # Configure the observe provider
 provider "observe" {}
 

--- a/.github/scripts/observe.tf
+++ b/.github/scripts/observe.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    observe = {
-      source  = "terraform.observeinc.com/observeinc/observe"
-     version = ">= 0.13.3"
-    }
-  }
-}
-
 # Configure the observe provider
 provider "observe" {}
 

--- a/.github/scripts/observe.tf
+++ b/.github/scripts/observe.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    observe = {
+      source  = "terraform.observeinc.com/observeinc/observe"
+     version = ">= 0.13.3"
+    }
+  }
+}
+
+# Configure the observe provider
+provider "observe" {}
+
+# Look up existing workspace 
+data "observe_workspace" "default" {
+  name = "Default"
+}

--- a/.github/scripts/observe/observe.tf
+++ b/.github/scripts/observe/observe.tf
@@ -11,7 +11,12 @@ terraform {
 # Configure the observe provider
 provider "observe" {}
 
+data "observe_datastream" "azure" {
+  workspace = data.observe_workspace.default.oid
+  name      = "Azure"
+}
+
 resource "observe_datastream_token" "github_actions_branch_token" {
-  datastream = data.observe_datastream.example.oid
+  datastream = data.observe_datastream.azure.oid
   name       = var.branch
 }

--- a/.github/scripts/observe/observe.tf
+++ b/.github/scripts/observe/observe.tf
@@ -1,4 +1,5 @@
 terraform {
+  backend "azurerm" {}
   required_providers {
     observe = {
       source  = "terraform.observeinc.com/observeinc/observe"

--- a/.github/scripts/observe/observe.tf
+++ b/.github/scripts/observe/observe.tf
@@ -11,6 +11,10 @@ terraform {
 # Configure the observe provider
 provider "observe" {}
 
+data "observe_workspace" "default" {
+  name = "Default"
+}
+
 data "observe_datastream" "azure" {
   workspace = data.observe_workspace.default.oid
   name      = "Azure"

--- a/.github/scripts/observe/observe.tf
+++ b/.github/scripts/observe/observe.tf
@@ -11,7 +11,7 @@ terraform {
 # Configure the observe provider
 provider "observe" {}
 
-# Look up existing workspace 
-data "observe_workspace" "default" {
-  name = "Default"
+resource "observe_datastream_token" "github_actions_branch_token" {
+  datastream = data.observe_datastream.example.oid
+  name       = var.branch
 }

--- a/.github/scripts/observe/outputs.tf
+++ b/.github/scripts/observe/outputs.tf
@@ -1,0 +1,4 @@
+output "observe_token" {
+  description = "Observe Token for Ephemeral Branch"
+  value       = azurerm_eventhub.observe_eventhub.name
+}

--- a/.github/scripts/observe/outputs.tf
+++ b/.github/scripts/observe/outputs.tf
@@ -1,4 +1,5 @@
 output "observe_token" {
   description = "Observe Token for Ephemeral Branch"
   value       = observe_datastream_token.github_actions_branch_token.secret
+  sensitive = true
 }

--- a/.github/scripts/observe/outputs.tf
+++ b/.github/scripts/observe/outputs.tf
@@ -1,4 +1,4 @@
-output "observe_token" {
-  description = "Observe Token for Ephemeral Branch"
-  value       = azurerm_eventhub.observe_eventhub.name
-}
+# output "observe_token" {
+#   description = "Observe Token for Ephemeral Branch"
+#   value       = azurerm_eventhub.observe_eventhub.name
+# }

--- a/.github/scripts/observe/outputs.tf
+++ b/.github/scripts/observe/outputs.tf
@@ -1,4 +1,4 @@
-# output "observe_token" {
-#   description = "Observe Token for Ephemeral Branch"
-#   value       = azurerm_eventhub.observe_eventhub.name
-# }
+output "observe_token" {
+  description = "Observe Token for Ephemeral Branch"
+  value       = observe_datastream_token.github_actions_branch_token.secret
+}

--- a/.github/scripts/observe/variables.tf
+++ b/.github/scripts/observe/variables.tf
@@ -1,0 +1,3 @@
+variable "branch" {
+  description = "Github Action Branch Name"
+}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    # Create branch name and branch name with special characters removed for use in override file 
     - name: Extract branch name
       id: extract_branch
       shell: bash
@@ -75,9 +76,9 @@ jobs:
         
                 
         jo -p terraform=$(jo backend=$(jo azurerm={})) \
-                resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="rg-${{ steps.extract_branch.outputs.branch }}")) \
-                azuread_application=$(jo observe_app_registration=$(jo display_name="app-${{ steps.extract_branch.outputs.branch }}")) \
-                azurerm_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch_concat }}"))) > override.tf.json
+                resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gh-rg-${{ steps.extract_branch.outputs.branch }}")) \
+                azuread_application=$(jo observe_app_registration=$(jo display_name="gh-app-${{ steps.extract_branch.outputs.branch }}")) \
+                azurerm_storage_account=$(jo observe_storage_account=$(jo name="ghsa${{ steps.extract_branch.outputs.branch_concat }}"))) > override.tf.json
         printenv | grep GITHUB
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
@@ -89,7 +90,6 @@ jobs:
         -backend-config="storage_account_name=citeststfazurecollection" \
         -backend-config="container_name=tfstate" \
         -backend-config="key=${{ steps.extract_branch.outputs.branch }}/.tfstate" 
-
 
 
     # Checks that all Terraform configuration files adhere to a canonical format

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,19 +32,19 @@ jobs:
       observe_token: ${{ steps.generate-token.outputs.token }}
     defaults:
         run:
-          working-directory: ${{github.workspace}}/.github/observe/scripts
+          working-directory: ${{github.workspace}}/.github/observe/scripts/observe 
     steps:
-     # Install the latest version of the Terraform CLI
      - name: Checkout
-       uses: actions/checkout@v4
-     - name: Extract branch name
-       shell: bash
-       run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-       id: extract_branch
+       uses: actions/checkout@v4     
      - name: Setup Terraform
        uses: hashicorp/setup-terraform@v3
        with:
         terraform_wrapper: false
+     - name: Extract branch name
+       id: extract_branch
+       shell: bash 
+       run: |
+          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
      - name: Generate Token
        id: generate-token
        env:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -39,15 +39,11 @@ jobs:
      - name: Setup Terraform
        uses: hashicorp/setup-terraform@v3
        with:
-        terraform_wrapper: false
-     - name: Extract branch name
-       id: extract_branch
-       run: |
-          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        terraform_wrapper: false     
      - name: Generate Token
        id: generate-token
-       env:
-         TF_VAR_branch: ${{ steps.extract_branch.outputs.branch }}
+    #    env:
+    #      TF_VAR_branch: ${{ steps.extract_branch.outputs.branch }}
        run: |
         terraform init -no-color     
         terraform plan -detailed-exitcode -no-color -out tfplan || exit 1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,17 +32,23 @@ jobs:
       observe_token: ${{ steps.generate-token.outputs.token }}
     defaults:
         run:
-          working-directory: ${{github.workspace}}/.github/scripts
+          working-directory: ${{github.workspace}}/.github/observe/scripts
     steps:
      # Install the latest version of the Terraform CLI
      - name: Checkout
        uses: actions/checkout@v4
+     - name: Extract branch name
+       shell: bash
+       run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+       id: extract_branch
      - name: Setup Terraform
        uses: hashicorp/setup-terraform@v3
        with:
         terraform_wrapper: false
      - name: Generate Token
        id: generate-token
+       env:
+         TF_VAR_branch: ${{ steps.extract_branch.outputs.branch }}
        run: |
         terraform init -no-color     
         terraform plan -detailed-exitcode -no-color -out tfplan || exit 1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -142,9 +142,9 @@ jobs:
       run: terraform apply -auto-approve tfplan
 
       
-    # # Terraform Destroy 
-    # - name: Terraform Destroy 
-    #   run: terraform destroy -auto-approve 
+    # Terraform Destroy 
+    - name: Terraform Destroy 
+      run: terraform destroy -auto-approve 
 
 
   

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -39,10 +39,15 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Extract branch name
+      id: extract_branch
       shell: bash
       run: |
          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | tr '/' '-' >> $GITHUB_OUTPUT
-      id: extract_branch
+         branch_remove_special="${branch//[-\/]}" # remove special characters
+         branch_concat="${branch_remove_special::0:20}" # concatinate to 20 characters
+         echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
+         cat $GITHUB_OUTPUT
+
 
     # Install the latest version of the Terraform CLI
     - name: Setup Terraform
@@ -55,6 +60,7 @@ jobs:
       shell: bash 
       run: |   
         sudo apt-get install --quiet=2 --assume-yes jo
+        
         
         # jo -p terraform=$(jo backend=$(jo azurerm={})) \
         #         resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gha-rg-${{ steps.extract_branch.outputs.branch }}")) \

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,7 +32,7 @@ jobs:
       observe_token: ${{ steps.generate-token.outputs.token }}
     defaults:
         run:
-            working-directory: '.github/scripts'
+          working-directory: ${{github.workspace}}/.github/scripts
     steps:
      # Install the latest version of the Terraform CLI
      - name: Setup Terraform
@@ -43,8 +43,8 @@ jobs:
      - name: Generate Token
        id: generate-token
        run: |
-        ls -l 
-        echo "Here"
+         ls -l 
+         echo "Here"
       
 
   ci-tests-ephemeral:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -42,7 +42,6 @@ jobs:
         terraform_wrapper: false
      - name: Extract branch name
        id: extract_branch
-       shell: bash 
        run: |
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
      - name: Generate Token

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,7 +51,7 @@ jobs:
          TF_VAR_branch: ${{ steps.extract_branch.outputs.branch }}
        run: |
         terraform init -no-color     
-        terraform plan -detailed-exitcode -no-color -out tfplan || exit 1
+        terraform plan -out tfplan 
         terraform apply -auto-approve tfplan
         export token=$(terraform output -raw observe_token)
         echo "observe_token=$token" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -64,7 +64,7 @@ jobs:
         jo -p terraform=$(jo backend=$(jo azurerm={})) \
                 resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="rg-${{ steps.extract_branch.outputs.branch }}")) \
                 azuread_application=$(jo observe_app_registration=$(jo display_name="app-${{ steps.extract_branch.outputs.branch }}")) \
-                azuread_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
+                azurerm_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
         printenv | grep GITHUB
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -91,6 +91,7 @@ jobs:
     - name: Create Override File
       run: |
        python .github/scripts/create_override.py   
+       printenv
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -139,6 +139,7 @@ jobs:
       if: steps.tf-plan.outputs.exitcode == 2
       run: terraform apply -auto-approve tfplan
 
+      
     # # Terraform Destroy 
     # - name: Terraform Destroy 
     #   run: terraform destroy -auto-approve 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -66,8 +66,6 @@ jobs:
     - name: Create Override providers file for backend   
       shell: bash 
       run: |   
-        echo ${{ steps.extract_branch.outputs.branch }}
-        echo ${{ steps.extract_branch.outputs.branch_concat }}
         sudo apt-get install --quiet=2 --assume-yes jo
         
         
@@ -79,7 +77,7 @@ jobs:
         jo -p terraform=$(jo backend=$(jo azurerm={})) \
                 resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="rg-${{ steps.extract_branch.outputs.branch }}")) \
                 azuread_application=$(jo observe_app_registration=$(jo display_name="app-${{ steps.extract_branch.outputs.branch }}")) \
-                azurerm_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
+                azurerm_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch_concat }}"))) > override.tf.json
         printenv | grep GITHUB
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,11 +17,7 @@ env:
   ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}" # Needed for azure provider service account 
   ARM_CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET }}" # Needed for azure provider service account 
   ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}" # Needed for azure provider service account 
-  ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}" # Needed for azure provider service account  
-  TF_VAR_observe_customer: "${{ vars.OBSERVE_CUSTOMER}}" #Fed to terraform-azure-collection 
-  TF_VAR_observe_domain: "${{ vars.OBSERVE_DOMAIN }}" #Fed to terraform-azure-collection 
-  #TF_VAR_observe_token: "${{ secrets.OBSERVE_TOKEN_CI_TESTS }}" #Fed to terraform-azure-collection 
-  TF_VAR_location: "centralus"  #CI Tests resource groups are created in centralus 
+  ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}" # Needed for azure provider service account   
   OBSERVE_CUSTOMER: ${{ vars.OBSERVE_CUSTOMER}} #Needed for observe.tf
   OBSERVE_DOMAIN: ${{ vars.OBSERVE_DOMAIN}} #Needed for observe.tf
   OBSERVE_USER_EMAIL: ${{ secrets.OBSERVE_USER_EMAIL}} #Needed for observe.tf
@@ -29,12 +25,39 @@ env:
   
 
 jobs:
+  generate-observe-token:
+    name: 'Generate Observe Token'
+    runs-on: ubuntu-latest
+    outputs:
+      observe_token: ${{ steps.generate-token.outputs.token }}
+    defaults:
+        run:
+            working-directory: '.github/scripts'
+    steps:
+     # Install the latest version of the Terraform CLI
+     - name: Setup Terraform
+       uses: hashicorp/setup-terraform@v3
+       with:
+        terraform_wrapper: false
+
+     - name: Generate Token
+       id: generate-token
+       run: |
+        ls -l 
+        echo "Here"
+      
+
   ci-tests-ephemeral:
     name: 'Collection CI Tests'
     runs-on: ubuntu-latest
+    needs: generate-observe-token
     env:
       #this is needed since we are running terraform with read-only permissions
       ARM_SKIP_PROVIDER_REGISTRATION: true
+      TF_VAR_observe_customer: "${{ vars.OBSERVE_CUSTOMER}}" #Fed to terraform-azure-collection 
+      TF_VAR_observe_domain: "${{ vars.OBSERVE_DOMAIN }}" #Fed to terraform-azure-collection 
+      TF_VAR_observe_token: "${{ needs.generate-observe-token.outputs.observe_token }}" #Fed to terraform-azure-collection 
+      TF_VAR_location: "centralus"  #CI Tests resource groups are created in centralus 
     outputs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 
@@ -59,7 +82,6 @@ jobs:
     - name: Create Override File
       run: |
        python .github/scripts/create_override.py   
-       mv .github/scripts/observe.tf . 
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,6 +43,7 @@ jobs:
       shell: bash
       run: |
          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | tr '/' '-' >> $GITHUB_OUTPUT
+         echo "branch name is $branch"
          branch_remove_special="${branch//[-\/]}" # remove special characters
          branch_concat="${branch_remove_special::0:20}" # concatinate to 20 characters
          echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -134,14 +134,14 @@ jobs:
       if: steps.tf-plan.outputs.exitcode == 1
       run: exit 1
 
-    # # Terraform Apply if no errors in plan & changes detected 
-    # - name: Terraform Apply     
-    #   if: steps.tf-plan.outputs.exitcode == 2
-    #   run: terraform apply -auto-approve tfplan
+    # Terraform Apply if no errors in plan & changes detected 
+    - name: Terraform Apply     
+      if: steps.tf-plan.outputs.exitcode == 2
+      run: terraform apply -auto-approve tfplan
 
-    # Terraform Destroy 
-    - name: Terraform Destroy 
-      run: terraform destroy -auto-approve 
+    # # Terraform Destroy 
+    # - name: Terraform Destroy 
+    #   run: terraform destroy -auto-approve 
 
 
   

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,16 +43,20 @@ jobs:
       id: extract_branch
       shell: bash
       run: |
-        # Extract branch name from GITHUB_REF
+        # Extract branch name from GITHUB_REF and save to $branch
         branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
         # Replace "/" with "-" in the branch name
         branch="${branch//\//-}"
         # Append the modified branch name to $GITHUB_OUTPUT
-        echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+        echo "branch=${branch}" >> "$GITHUB_OUTPUT"  
+
+        # Convert branch name to lowercase, remove special characters, save to $branch_concat
         # remove special characters
         branch_remove_special="${branch//[-\/]}" 
+        # Convert to lowercase
+        branch_lowercase=$(echo "$branch_remove_special" | awk '{print tolower($0)}')
         # concatinate to 20 characters
-        branch_concat="${branch_remove_special:0:20}" 
+        branch_concat="${branch_lowercase:0:20}" 
         # Append the concat branch name to $GITHUB_OUTPUT
         echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,7 +52,7 @@ jobs:
          python-version: '3.10' 
         
     - name: Create Override File
-      run: pip install python-dotenv && python .github/scripts/create_override.py
+      run:  python .github/scripts/create_override.py
       
     # # Create branch name and branch name with special characters removed for use in override file 
     # - name: Extract branch name

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -46,7 +46,6 @@ jobs:
          branch_remove_special="${branch//[-\/]}" # remove special characters
          branch_concat="${branch_remove_special::0:20}" # concatinate to 20 characters
          echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
-         cat $GITHUB_OUTPUT
 
 
     # Install the latest version of the Terraform CLI
@@ -59,6 +58,7 @@ jobs:
     - name: Create Override providers file for backend   
       shell: bash 
       run: |   
+        cat $GITHUB_OUTPUT
         sudo apt-get install --quiet=2 --assume-yes jo
         
         

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -25,57 +25,57 @@ env:
   
 
 jobs:
-  generate-observe-token:
-    name: 'Generate Observe Token'
-    runs-on: ubuntu-latest
-    outputs:
-      observe_token: ${{ steps.generate-token.outputs.token }}
-    defaults:
-        run:
-          working-directory: ${{github.workspace}}/.github/scripts/observe
-    steps:
-     - name: Checkout
-       uses: actions/checkout@v4     
-     - name: Setup Terraform
-       uses: hashicorp/setup-terraform@v3
-       with:
-        terraform_wrapper: false
-     - name: Extract branch name
-       id: extract_branch
-       shell: bash 
-       run: |
-         # Extract branch name from GITHUB_REF and save to $branch
-         branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-         # Replace "/" with "-" in the branch name
-         branch="${branch//\//-}"
-         # Append the modified branch name to $GITHUB_OUTPUT
-         echo "branch=${branch}" >> "$GITHUB_OUTPUT"  
-     - name: Generate Token
-       id: generate-token
-       env:
-         TF_VAR_branch: "terraform-ci-${{ steps.extract_branch.outputs.branch }}"
-       run: |
-        terraform init -no-color \
-            -backend-config="resource_group_name=rg-terraform-github-actions-state" \
-            -backend-config="storage_account_name=citeststfazurecollection" \
-            -backend-config="container_name=observetfstate" \
-            -backend-config="key=${{ steps.extract_branch.outputs.branch }}/.tfstate"                 
-        terraform plan -out tfplan 
-        terraform apply -auto-approve tfplan
-        export token=$(terraform output -raw observe_token)
-        echo "observe_token=$token" >> $GITHUB_OUTPUT
+  # generate-observe-token:
+  #   name: 'Generate Observe Token'
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     observe_token: ${{ steps.generate-token.outputs.token }}
+  #   defaults:
+  #       run:
+  #         working-directory: ${{github.workspace}}/.github/scripts/observe
+  #   steps:
+  #    - name: Checkout
+  #      uses: actions/checkout@v4     
+  #    - name: Setup Terraform
+  #      uses: hashicorp/setup-terraform@v3
+  #      with:
+  #       terraform_wrapper: false
+  #    - name: Extract branch name
+  #      id: extract_branch
+  #      shell: bash 
+  #      run: |
+  #        # Extract branch name from GITHUB_REF and save to $branch
+  #        branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+  #        # Replace "/" with "-" in the branch name
+  #        branch="${branch//\//-}"
+  #        # Append the modified branch name to $GITHUB_OUTPUT
+  #        echo "branch=${branch}" >> "$GITHUB_OUTPUT"  
+  #    - name: Generate Token
+  #      id: generate-token
+  #      env:
+  #        TF_VAR_branch: "terraform-ci-${{ steps.extract_branch.outputs.branch }}"
+  #      run: |
+  #       terraform init -no-color \
+  #           -backend-config="resource_group_name=rg-terraform-github-actions-state" \
+  #           -backend-config="storage_account_name=citeststfazurecollection" \
+  #           -backend-config="container_name=observetfstate" \
+  #           -backend-config="key=${{ steps.extract_branch.outputs.branch }}/.tfstate"                 
+  #       terraform plan -out tfplan 
+  #       terraform apply -auto-approve tfplan
+  #       export token=$(terraform output -raw observe_token)
+  #       echo "observe_token=$token" >> $GITHUB_OUTPUT
     
 
   ci-tests-ephemeral:
     name: 'Collection CI Tests'
     runs-on: ubuntu-latest
-    needs: generate-observe-token
+    #needs: generate-observe-token
     env:
       #this is needed since we are running terraform with read-only permissions
       ARM_SKIP_PROVIDER_REGISTRATION: true
       TF_VAR_observe_customer: "${{ vars.OBSERVE_CUSTOMER}}" #Fed to terraform-azure-collection 
       TF_VAR_observe_domain: "${{ vars.OBSERVE_DOMAIN }}" #Fed to terraform-azure-collection 
-      TF_VAR_observe_token: "${{ needs.generate-observe-token.outputs.observe_token }}" #Fed to terraform-azure-collection 
+      #TF_VAR_observe_token: "${{ needs.generate-observe-token.outputs.observe_token }}" #Fed to terraform-azure-collection 
       TF_VAR_location: "centralus"  #CI Tests resource groups are created in centralus 
     outputs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -44,13 +44,22 @@ jobs:
        id: extract_branch
        shell: bash 
        run: |
-          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+         # Extract branch name from GITHUB_REF and save to $branch
+         branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+         # Replace "/" with "-" in the branch name
+         branch="${branch//\//-}"
+         # Append the modified branch name to $GITHUB_OUTPUT
+         echo "branch=${branch}" >> "$GITHUB_OUTPUT"  
      - name: Generate Token
        id: generate-token
        env:
-         TF_VAR_branch: "terrform-ci-${{ steps.extract_branch.outputs.branch }}"
+         TF_VAR_branch: "terraform-ci-${{ steps.extract_branch.outputs.branch }}"
        run: |
-        terraform init -no-color     
+        terraform init -no-color \
+            -backend-config="resource_group_name=rg-terraform-github-actions-state" \
+            -backend-config="storage_account_name="citeststfazurecollection" \
+            -backend-config="container_name=observetfstate" \
+            -backend-config="key=${{ steps.extract_branch.outputs.branch }} + "/.tfstate"                 
         terraform plan -out tfplan 
         terraform apply -auto-approve tfplan
         export token=$(terraform output -raw observe_token)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -59,7 +59,7 @@ jobs:
             -backend-config="resource_group_name=rg-terraform-github-actions-state" \
             -backend-config="storage_account_name="citeststfazurecollection" \
             -backend-config="container_name=observetfstate" \
-            -backend-config="key=${{ steps.extract_branch.outputs.branch }} + "/.tfstate"                 
+            -backend-config="key=${{ steps.extract_branch.outputs.branch }}/.tfstate"                 
         terraform plan -out tfplan 
         terraform apply -auto-approve tfplan
         export token=$(terraform output -raw observe_token)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -42,11 +42,23 @@ jobs:
       id: extract_branch
       shell: bash
       run: |
-         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | tr '/' '-' >> $GITHUB_OUTPUT
-         echo "branch name is $branch"
-         branch_remove_special="${branch//[-\/]}" # remove special characters
-         branch_concat="${branch_remove_special::0:20}" # concatinate to 20 characters
-         echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
+        # Extract branch name from GITHUB_REF
+        branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+
+        # Replace "/" with "-" in the branch name
+        branch="${branch//\//-}"
+
+        # Append the modified branch name to $GITHUB_OUTPUT
+        echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+
+        echo "branch name is $branch"
+
+
+        #  echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | tr '/' '-' >> $GITHUB_OUTPUT
+        #  echo "branch name is $branch"
+        #  branch_remove_special="${branch//[-\/]}" # remove special characters
+        #  branch_concat="${branch_remove_special::0:20}" # concatinate to 20 characters
+        #  echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
 
 
     # Install the latest version of the Terraform CLI

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -58,7 +58,8 @@ jobs:
     - name: Create Override providers file for backend   
       shell: bash 
       run: |   
-        cat $GITHUB_OUTPUT
+        echo ${{ steps.extract_branch.outputs.branch }}
+        echo ${{ steps.extract_branch.outputs.branch_concat }}
         sudo apt-get install --quiet=2 --assume-yes jo
         
         

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
        python .github/scripts/create_override.py   
        mv .github/scripts/observe.tf . 
+       ls -l 
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,18 +32,23 @@ jobs:
       observe_token: ${{ steps.generate-token.outputs.token }}
     defaults:
         run:
-          working-directory: ${{github.workspace}}/.github/observe/scripts
+          working-directory: ${{github.workspace}}/.github/scripts/observe
     steps:
      - name: Checkout
        uses: actions/checkout@v4     
      - name: Setup Terraform
        uses: hashicorp/setup-terraform@v3
        with:
-        terraform_wrapper: false     
+        terraform_wrapper: false
+     - name: Extract branch name
+       id: extract_branch
+       shell: bash 
+       run: |
+          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
      - name: Generate Token
        id: generate-token
-    #    env:
-    #      TF_VAR_branch: ${{ steps.extract_branch.outputs.branch }}
+       env:
+         TF_VAR_branch: ${{ steps.extract_branch.outputs.branch }}
        run: |
         terraform init -no-color     
         terraform plan -detailed-exitcode -no-color -out tfplan || exit 1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,8 +76,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     
-    
-    # Install the latest version of the Terraform CLI
+        # Install the latest version of the Terraform CLI
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -100,9 +100,9 @@ jobs:
       if: steps.tf-plan.outputs.exitcode == 1
       run: exit 1
 
-    # # Terraform Apply if no errors in plan & changes detected 
-    # - name: Terraform Apply     
-    #   if: steps.tf-plan.outputs.exitcode == 2
-    #   run: terraform apply -auto-approve tfplan
+    # Terraform Apply if no errors in plan & changes detected 
+    - name: Terraform Apply     
+      if: steps.tf-plan.outputs.exitcode == 2
+      run: terraform apply -auto-approve tfplan
 
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -64,7 +64,7 @@ jobs:
         jo -p terraform=$(jo backend=$(jo azurerm={})) \
                 resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="rg-${{ steps.extract_branch.outputs.branch }}")) \
                 azuread_application=$(jo observe_app_registration=$(jo display_name="app-${{ steps.extract_branch.outputs.branch }}")) \
-                azuread_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch }}))) > override.tf.json
+                azuread_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
         printenv | grep GITHUB
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -44,21 +44,16 @@ jobs:
       run: |
         # Extract branch name from GITHUB_REF
         branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-
         # Replace "/" with "-" in the branch name
         branch="${branch//\//-}"
-
         # Append the modified branch name to $GITHUB_OUTPUT
         echo "branch=${branch}" >> "$GITHUB_OUTPUT"
-
-        echo "branch name is $branch"
-
-
-        #  echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | tr '/' '-' >> $GITHUB_OUTPUT
-        #  echo "branch name is $branch"
-        #  branch_remove_special="${branch//[-\/]}" # remove special characters
-        #  branch_concat="${branch_remove_special::0:20}" # concatinate to 20 characters
-        #  echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
+        # remove special characters
+        branch_remove_special="${branch//[-\/]}" 
+        # concatinate to 20 characters
+        branch_concat="${branch_remove_special::0:20}" 
+        # Append the concat branch name to $GITHUB_OUTPUT
+        echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
 
 
     # Install the latest version of the Terraform CLI

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,11 +35,12 @@ jobs:
           working-directory: ${{github.workspace}}/.github/scripts
     steps:
      # Install the latest version of the Terraform CLI
+     - name: Checkout
+       uses: actions/checkout@v4
      - name: Setup Terraform
        uses: hashicorp/setup-terraform@v3
        with:
         terraform_wrapper: false
-
      - name: Generate Token
        id: generate-token
        run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,7 +57,7 @@ jobs:
        run: |
         terraform init -no-color \
             -backend-config="resource_group_name=rg-terraform-github-actions-state" \
-            -backend-config="storage_account_name="citeststfazurecollection" \
+            -backend-config="storage_account_name=citeststfazurecollection" \
             -backend-config="container_name=observetfstate" \
             -backend-config="key=${{ steps.extract_branch.outputs.branch }}/.tfstate"                 
         terraform plan -out tfplan 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -134,9 +134,16 @@ jobs:
       if: steps.tf-plan.outputs.exitcode == 1
       run: exit 1
 
-    # Terraform Apply if no errors in plan & changes detected 
-    - name: Terraform Apply     
-      if: steps.tf-plan.outputs.exitcode == 2
-      run: terraform apply -auto-approve tfplan
+    # # Terraform Apply if no errors in plan & changes detected 
+    # - name: Terraform Apply     
+    #   if: steps.tf-plan.outputs.exitcode == 2
+    #   run: terraform apply -auto-approve tfplan
+
+    # Terraform Destroy 
+    - name: Terraform Destroy 
+      run: terraform destroy -auto-approve tfplan
+
+
+  
 
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,8 +52,8 @@ jobs:
          python-version: '3.10' 
         
     - name: Create Override File
-      run:  python .github/scripts/create_override.py
-   
+      run: |
+       python .github/scripts/create_override.py   
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -117,29 +117,29 @@ jobs:
       id: validate
       run: terraform validate -no-color
 
-    # Generates an execution plan for Terraform
-    # An exit code of 0 indicated no changes, 1 a terraform failure, 2 there are pending changes.
-    - name: Terraform Plan
-      id: tf-plan
-      run: |
-        export exitcode=0
-        terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
-        echo "exitcode=$exitcode" >> $GITHUB_OUTPUT        
-        if [ $exitcode -eq 1 ]; then
-          echo Terraform Plan Failed!
-          exit 1
-        else 
-          exit 0
-        fi
+    # # Generates an execution plan for Terraform
+    # # An exit code of 0 indicated no changes, 1 a terraform failure, 2 there are pending changes.
+    # - name: Terraform Plan
+    #   id: tf-plan
+    #   run: |
+    #     export exitcode=0
+    #     terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
+    #     echo "exitcode=$exitcode" >> $GITHUB_OUTPUT        
+    #     if [ $exitcode -eq 1 ]; then
+    #       echo Terraform Plan Failed!
+    #       exit 1
+    #     else 
+    #       exit 0
+    #     fi
 
-    - name: Error in Terraform 
-      if: steps.tf-plan.outputs.exitcode == 1
-      run: exit 1
+    # - name: Error in Terraform 
+    #   if: steps.tf-plan.outputs.exitcode == 1
+    #   run: exit 1
 
-    # Terraform Apply if no errors in plan & changes detected 
-    - name: Terraform Apply     
-      if: steps.tf-plan.outputs.exitcode == 2
-      run: terraform apply -auto-approve tfplan
+    # # Terraform Apply if no errors in plan & changes detected 
+    # - name: Terraform Apply     
+    #   if: steps.tf-plan.outputs.exitcode == 2
+    #   run: terraform apply -auto-approve tfplan
 
       
     # Terraform Destroy 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -60,7 +60,6 @@ jobs:
       run: |
        python .github/scripts/create_override.py   
        mv .github/scripts/observe.tf . 
-       ls -l 
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -55,9 +55,16 @@ jobs:
       shell: bash 
       run: |   
         sudo apt-get install --quiet=2 --assume-yes jo
+        
+        # jo -p terraform=$(jo backend=$(jo azurerm={})) \
+        #         resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gha-rg-${{ steps.extract_branch.outputs.branch }}")) \
+        #         jo azuread_application=$(jo observe_app_registration=$(jo display_name="gha-app-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
+        
+                
         jo -p terraform=$(jo backend=$(jo azurerm={})) \
-                resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gha-rg-${{ steps.extract_branch.outputs.branch }}")) \
-                jo azuread_application=$(jo observe_app_registration=$(jo display_name="gha-app-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
+                resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="rg-${{ steps.extract_branch.outputs.branch }}")) \
+                azuread_application=$(jo observe_app_registration=$(jo display_name="app-${{ steps.extract_branch.outputs.branch }}")) \
+                azuread_storage_account=$(jo observe_storage_account=$(jo name="sa-${{ steps.extract_branch.outputs.branch }}))) > override.tf.json
         printenv | grep GITHUB
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,7 +32,7 @@ jobs:
       observe_token: ${{ steps.generate-token.outputs.token }}
     defaults:
         run:
-          working-directory: ${{github.workspace}}/.github/observe/scripts/observe 
+          working-directory: ${{github.workspace}}/.github/observe/scripts
     steps:
      - name: Checkout
        uses: actions/checkout@v4     

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,14 +14,19 @@ permissions:
 
 #These environment variables are used by the terraform azure provider to setup OIDD authenticate. 
 env:
-  ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
-  ARM_CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET }}"
-  ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-  ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
-  TF_VAR_observe_customer: "${{ vars.OBSERVE_CUSTOMER}}"
-  TF_VAR_observe_domain: "${{ vars.OBSERVE_DOMAIN }}"
-  TF_VAR_observe_token: "${{ secrets.OBSERVE_TOKEN_CI_TESTS }}"
+  ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}" # Needed for azure provider service account 
+  ARM_CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET }}" # Needed for azure provider service account 
+  ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}" # Needed for azure provider service account 
+  ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}" # Needed for azure provider service account  
+  TF_VAR_observe_customer: "${{ vars.OBSERVE_CUSTOMER}}" #Fed to terraform-azure-collection 
+  TF_VAR_observe_domain: "${{ vars.OBSERVE_DOMAIN }}" #Fed to terraform-azure-collection 
+  #TF_VAR_observe_token: "${{ secrets.OBSERVE_TOKEN_CI_TESTS }}" #Fed to terraform-azure-collection 
   TF_VAR_location: "centralus"  #CI Tests resource groups are created in centralus 
+  OBSERVE_CUSTOMER: ${{ vars.OBSERVE_CUSTOMER}} #Needed for observe.tf
+  OBSERVE_DOMAIN: ${{ vars.OBSERVE_DOMAIN}} #Needed for observe.tf
+  OBSERVE_USER_EMAIL: ${{ secrets.OBSERVE_USER_EMAIL}} #Needed for observe.tf
+  OBSERVE_USER_PASSWORD: ${{ secrets.OBSERVE_USER_PASSWORD}} #Needed for observe.tf
+  
 
 jobs:
   ci-tests-ephemeral:
@@ -54,6 +59,7 @@ jobs:
     - name: Create Override File
       run: |
        python .github/scripts/create_override.py   
+       mv .github/scripts/observe.tf . 
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -37,53 +37,63 @@ jobs:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v4
-
-    # Create branch name and branch name with special characters removed for use in override file 
-    - name: Extract branch name
-      id: extract_branch
-      shell: bash
-      run: |
-        # Extract branch name from GITHUB_REF and save to $branch
-        branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-        # Replace "/" with "-" in the branch name
-        branch="${branch//\//-}"
-        # Append the modified branch name to $GITHUB_OUTPUT
-        echo "branch=${branch}" >> "$GITHUB_OUTPUT"  
-
-        # Convert branch name to lowercase, remove special characters, save to $branch_concat
-        # remove special characters
-        branch_remove_special="${branch//[-\/]}" 
-        # Convert to lowercase
-        branch_lowercase=$(echo "$branch_remove_special" | awk '{print tolower($0)}')
-        # concatinate to 20 characters
-        branch_concat="${branch_lowercase:0:20}" 
-        # Append the concat branch name to $GITHUB_OUTPUT
-        echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
-
-
+    
+    
     # Install the latest version of the Terraform CLI
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_wrapper: false
 
+    # Install Python
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+         python-version: '3.10' 
+        
+    - name: Create Override File
+      run: python .github/scripts/create_override.py
+      
+    # # Create branch name and branch name with special characters removed for use in override file 
+    # - name: Extract branch name
+    #   id: extract_branch
+    #   shell: bash
+    #   run: |
+    #     # Extract branch name from GITHUB_REF and save to $branch
+    #     branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+    #     # Replace "/" with "-" in the branch name
+    #     branch="${branch//\//-}"
+    #     # Append the modified branch name to $GITHUB_OUTPUT
+    #     echo "branch=${branch}" >> "$GITHUB_OUTPUT"  
 
-    - name: Create Override providers file for backend   
-      shell: bash 
-      run: |   
-        sudo apt-get install --quiet=2 --assume-yes jo
+    #     # Convert branch name to lowercase, remove special characters, save to $branch_concat
+    #     # remove special characters
+    #     branch_remove_special="${branch//[-\/]}" 
+    #     # Convert to lowercase
+    #     branch_lowercase=$(echo "$branch_remove_special" | awk '{print tolower($0)}')
+    #     # concatinate to 20 characters
+    #     branch_concat="${branch_lowercase:0:20}" 
+    #     # Append the concat branch name to $GITHUB_OUTPUT
+    #     echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
+
+
+
+    # - name: Create Override providers file for backend   
+    #   shell: bash 
+    #   run: |   
+    #     sudo apt-get install --quiet=2 --assume-yes jo
         
         
-        # jo -p terraform=$(jo backend=$(jo azurerm={})) \
-        #         resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gha-rg-${{ steps.extract_branch.outputs.branch }}")) \
-        #         jo azuread_application=$(jo observe_app_registration=$(jo display_name="gha-app-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
+    #     # jo -p terraform=$(jo backend=$(jo azurerm={})) \
+    #     #         resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gha-rg-${{ steps.extract_branch.outputs.branch }}")) \
+    #     #         jo azuread_application=$(jo observe_app_registration=$(jo display_name="gha-app-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
         
                 
-        jo -p terraform=$(jo backend=$(jo azurerm={})) \
-                resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gh-rg-${{ steps.extract_branch.outputs.branch }}")) \
-                azuread_application=$(jo observe_app_registration=$(jo display_name="gh-app-${{ steps.extract_branch.outputs.branch }}")) \
-                azurerm_storage_account=$(jo observe_storage_account=$(jo name="ghsa${{ steps.extract_branch.outputs.branch_concat }}"))) > override.tf.json
-        printenv | grep GITHUB
+    #     jo -p terraform=$(jo backend=$(jo azurerm={})) \
+    #             resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gh-rg-${{ steps.extract_branch.outputs.branch }}")) \
+    #             azuread_application=$(jo observe_app_registration=$(jo display_name="gh-app-${{ steps.extract_branch.outputs.branch }}")) \
+    #             azurerm_storage_account=$(jo observe_storage_account=$(jo name="ghsa${{ steps.extract_branch.outputs.branch_concat }}"))) > override.tf.json
+    #     printenv | grep GITHUB
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -48,7 +48,7 @@ jobs:
      - name: Generate Token
        id: generate-token
        env:
-         TF_VAR_branch: ${{ steps.extract_branch.outputs.branch }}
+         TF_VAR_branch: "terrform-ci-${{ steps.extract_branch.outputs.branch }}"
        run: |
         terraform init -no-color     
         terraform plan -out tfplan 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -141,7 +141,7 @@ jobs:
 
     # Terraform Destroy 
     - name: Terraform Destroy 
-      run: terraform destroy -auto-approve tfplan
+      run: terraform destroy -auto-approve 
 
 
   

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -44,9 +44,12 @@ jobs:
      - name: Generate Token
        id: generate-token
        run: |
-         ls -l 
-         echo "Here"
-      
+        terraform init -no-color     
+        terraform plan -detailed-exitcode -no-color -out tfplan || exit 1
+        terraform apply -auto-approve tfplan
+        export token=$(terraform output -raw observe_token)
+        echo "observe_token=$token" >> $GITHUB_OUTPUT
+    
 
   ci-tests-ephemeral:
     name: 'Collection CI Tests'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,7 +52,7 @@ jobs:
          python-version: '3.10' 
         
     - name: Create Override File
-      run: python .github/scripts/create_override.py
+      run: pip install python-dotenv && python .github/scripts/create_override.py
       
     # # Create branch name and branch name with special characters removed for use in override file 
     # - name: Extract branch name

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,8 +24,8 @@ env:
   TF_VAR_location: "centralus"  #CI Tests resource groups are created in centralus 
 
 jobs:
-  terraform-plan:
-    name: 'Terraform Plan'
+  ci-tests-ephemeral:
+    name: 'Collection CI Tests'
     runs-on: ubuntu-latest
     env:
       #this is needed since we are running terraform with read-only permissions
@@ -53,58 +53,13 @@ jobs:
         
     - name: Create Override File
       run:  python .github/scripts/create_override.py
-      
-    # # Create branch name and branch name with special characters removed for use in override file 
-    # - name: Extract branch name
-    #   id: extract_branch
-    #   shell: bash
-    #   run: |
-    #     # Extract branch name from GITHUB_REF and save to $branch
-    #     branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-    #     # Replace "/" with "-" in the branch name
-    #     branch="${branch//\//-}"
-    #     # Append the modified branch name to $GITHUB_OUTPUT
-    #     echo "branch=${branch}" >> "$GITHUB_OUTPUT"  
-
-    #     # Convert branch name to lowercase, remove special characters, save to $branch_concat
-    #     # remove special characters
-    #     branch_remove_special="${branch//[-\/]}" 
-    #     # Convert to lowercase
-    #     branch_lowercase=$(echo "$branch_remove_special" | awk '{print tolower($0)}')
-    #     # concatinate to 20 characters
-    #     branch_concat="${branch_lowercase:0:20}" 
-    #     # Append the concat branch name to $GITHUB_OUTPUT
-    #     echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
-
-
-
-    # - name: Create Override providers file for backend   
-    #   shell: bash 
-    #   run: |   
-    #     sudo apt-get install --quiet=2 --assume-yes jo
-        
-        
-    #     # jo -p terraform=$(jo backend=$(jo azurerm={})) \
-    #     #         resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gha-rg-${{ steps.extract_branch.outputs.branch }}")) \
-    #     #         jo azuread_application=$(jo observe_app_registration=$(jo display_name="gha-app-${{ steps.extract_branch.outputs.branch }}"))) > override.tf.json
-        
-                
-    #     jo -p terraform=$(jo backend=$(jo azurerm={})) \
-    #             resource=$(jo azurerm_resource_group=$(jo observe_resource_group=$(jo name="gh-rg-${{ steps.extract_branch.outputs.branch }}")) \
-    #             azuread_application=$(jo observe_app_registration=$(jo display_name="gh-app-${{ steps.extract_branch.outputs.branch }}")) \
-    #             azurerm_storage_account=$(jo observe_storage_account=$(jo name="ghsa${{ steps.extract_branch.outputs.branch_concat }}"))) > override.tf.json
-    #     printenv | grep GITHUB
+   
    
     #Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       id: init
       run: |
-        terraform init -no-color \
-        -backend-config="resource_group_name=rg-terraform-github-actions-state" \
-        -backend-config="storage_account_name=citeststfazurecollection" \
-        -backend-config="container_name=tfstate" \
-        -backend-config="key=${{ steps.extract_branch.outputs.branch }}/.tfstate" 
-
+        terraform init -no-color     
 
     # Checks that all Terraform configuration files adhere to a canonical format
     # Will fail the build if not

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,7 +51,7 @@ jobs:
         # remove special characters
         branch_remove_special="${branch//[-\/]}" 
         # concatinate to 20 characters
-        branch_concat="${branch_remove_special::0:20}" 
+        branch_concat="${branch_remove_special:0:20}" 
         # Append the concat branch name to $GITHUB_OUTPUT
         echo "branch_concat=${branch_concat}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -1,174 +1,174 @@
-# Job is to test basic plan & apply with fixed data and fixed environment 
-# with data getting sent to 179 datastream.  
-name: 'Terraform Plan/Apply: Fixed Environment'
+# # Job is to test basic plan & apply with fixed data and fixed environment 
+# # with data getting sent to 179 datastream.  
+# name: 'Terraform Plan/Apply: Fixed Environment'
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
-  workflow_dispatch:
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#     types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
+#   workflow_dispatch:
 
-#Special permissions required for OIDC authentication
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
+# #Special permissions required for OIDC authentication
+# permissions:
+#   id-token: write
+#   contents: read
+#   pull-requests: write
 
-env:
-  ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
-  ARM_CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET }}"
-  ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-  ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
-  TF_VAR_observe_customer: "${{ vars.OBSERVE_CUSTOMER}}"
-  TF_VAR_observe_domain: "${{ vars.OBSERVE_DOMAIN }}"
-  TF_VAR_observe_token: "${{ secrets.OBSERVE_TOKEN }}"
+# env:
+#   ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
+#   ARM_CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET }}"
+#   ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+#   ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
+#   TF_VAR_observe_customer: "${{ vars.OBSERVE_CUSTOMER}}"
+#   TF_VAR_observe_domain: "${{ vars.OBSERVE_DOMAIN }}"
+#   TF_VAR_observe_token: "${{ secrets.OBSERVE_TOKEN }}"
 
 
-jobs:
-  terraform-plan:
-    name: 'Terraform Plan'
-    runs-on: ubuntu-latest
-    env:
-      #this is needed since we are running terraform with read-only permissions
-      ARM_SKIP_PROVIDER_REGISTRATION: true
-    outputs:
-      tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
+# jobs:
+#   terraform-plan:
+#     name: 'Terraform Plan'
+#     runs-on: ubuntu-latest
+#     env:
+#       #this is needed since we are running terraform with read-only permissions
+#       ARM_SKIP_PROVIDER_REGISTRATION: true
+#     outputs:
+#       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v4
+#     steps:
+#     # Checkout the repository to the GitHub Actions runner
+#     - name: Checkout
+#       uses: actions/checkout@v4
 
-    # Install the latest version of the Terraform CLI
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_wrapper: false
+#     # Install the latest version of the Terraform CLI
+#     - name: Setup Terraform
+#       uses: hashicorp/setup-terraform@v3
+#       with:
+#         terraform_wrapper: false
 
-    - name: Create Override providers file for backend   
-      shell: bash 
-      run: |   
-          sudo apt-get install --quiet=2 --assume-yes jo
-          jo -p terraform=$(jo backend=$(jo azurerm={})) > override.tf.json
+#     - name: Create Override providers file for backend   
+#       shell: bash 
+#       run: |   
+#           sudo apt-get install --quiet=2 --assume-yes jo
+#           jo -p terraform=$(jo backend=$(jo azurerm={})) > override.tf.json
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      id: init
-      run: |
-        terraform init -no-color \
-          -backend-config="resource_group_name=rg-terraform-github-actions-state" \
-          -backend-config="storage_account_name=terraformazurecollection" \
-          -backend-config="container_name=tfstate" \
-          -backend-config="key=terraform.tfstate" 
+#     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+#     - name: Terraform Init
+#       id: init
+#       run: |
+#         terraform init -no-color \
+#           -backend-config="resource_group_name=rg-terraform-github-actions-state" \
+#           -backend-config="storage_account_name=terraformazurecollection" \
+#           -backend-config="container_name=tfstate" \
+#           -backend-config="key=terraform.tfstate" 
 
-  # Checks that all Terraform configuration files adhere to a canonical format
-    # Will fail the build if not
-    - name: Terraform Format
-      run: terraform fmt -check
+#   # Checks that all Terraform configuration files adhere to a canonical format
+#     # Will fail the build if not
+#     - name: Terraform Format
+#       run: terraform fmt -check
 
-    - name: Terraform Validate
-      id: validate
-      run: terraform validate -no-color
+#     - name: Terraform Validate
+#       id: validate
+#       run: terraform validate -no-color
 
-    # Generates an execution plan for Terraform
-    # An exit code of 0 indicated no changes, 1 a terraform failure, 2 there are pending changes.
-    - name: Terraform Plan
-      id: tf-plan
-      run: |
-        export exitcode=0
-        terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
+#     # Generates an execution plan for Terraform
+#     # An exit code of 0 indicated no changes, 1 a terraform failure, 2 there are pending changes.
+#     - name: Terraform Plan
+#       id: tf-plan
+#       run: |
+#         export exitcode=0
+#         terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
 
-        echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+#         echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
         
-        if [ $exitcode -eq 1 ]; then
-          echo Terraform Plan Failed!
-          exit 1
-        else 
-          exit 0
-        fi
+#         if [ $exitcode -eq 1 ]; then
+#           echo Terraform Plan Failed!
+#           exit 1
+#         else 
+#           exit 0
+#         fi
 
-    # Save plan to artifacts  
-    - name: Publish Terraform Plan
-      uses: actions/upload-artifact@v4
-      with:
-        name: tfplan
-        path: tfplan
+#     # Save plan to artifacts  
+#     - name: Publish Terraform Plan
+#       uses: actions/upload-artifact@v4
+#       with:
+#         name: tfplan
+#         path: tfplan
             
 
-    # Create string output of Terraform Plan
-    - name: Create String Output
-      id: tf-plan-string
-      run: |
-        TERRAFORM_PLAN=$(terraform show -no-color tfplan)
+#     # Create string output of Terraform Plan
+#     - name: Create String Output
+#       id: tf-plan-string
+#       run: |
+#         TERRAFORM_PLAN=$(terraform show -no-color tfplan)
         
-        delimiter="$(openssl rand -hex 8)"
-        echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
-        echo "## Terraform Plan Output" >> $GITHUB_OUTPUT
-        echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
-        echo "" >> $GITHUB_OUTPUT
-        echo '```terraform' >> $GITHUB_OUTPUT
-        echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
-        echo '```' >> $GITHUB_OUTPUT
-        echo "</details>" >> $GITHUB_OUTPUT
-        echo "${delimiter}" >> $GITHUB_OUTPUT
+#         delimiter="$(openssl rand -hex 8)"
+#         echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
+#         echo "## Terraform Plan Output" >> $GITHUB_OUTPUT
+#         echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
+#         echo "" >> $GITHUB_OUTPUT
+#         echo '```terraform' >> $GITHUB_OUTPUT
+#         echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
+#         echo '```' >> $GITHUB_OUTPUT
+#         echo "</details>" >> $GITHUB_OUTPUT
+#         echo "${delimiter}" >> $GITHUB_OUTPUT
       
-    # Publish Terraform Plan as task summary
-    - name: Publish Terraform Plan to Task Summary
-      env:
-        SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
-      run: |
-        echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+#     # Publish Terraform Plan as task summary
+#     - name: Publish Terraform Plan to Task Summary
+#       env:
+#         SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
+#       run: |
+#         echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
 
-    # If this is a PR post the changes
-    - name: Push Terraform Output to PR
-      if: github.ref != 'refs/heads/main'
-      uses: actions/github-script@v7
-      env:
-        SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
-      with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const body = `${process.env.SUMMARY}`;
-            github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body
-            })
+#     # If this is a PR post the changes
+#     - name: Push Terraform Output to PR
+#       if: github.ref != 'refs/heads/main'
+#       uses: actions/github-script@v7
+#       env:
+#         SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
+#       with:
+#           github-token: ${{ secrets.GITHUB_TOKEN }}
+#           script: |
+#             const body = `${process.env.SUMMARY}`;
+#             github.rest.issues.createComment({
+#                 issue_number: context.issue.number,
+#                 owner: context.repo.owner,
+#                 repo: context.repo.repo,
+#                 body: body
+#             })
         
-  terraform-apply:
-    name: 'Terraform Apply'
-    if: github.ref == 'refs/heads/main' && needs.terraform-plan.outputs.tfplanExitCode == 2
-    runs-on: ubuntu-latest
-    needs: [terraform-plan]
+#   terraform-apply:
+#     name: 'Terraform Apply'
+#     if: github.ref == 'refs/heads/main' && needs.terraform-plan.outputs.tfplanExitCode == 2
+#     runs-on: ubuntu-latest
+#     needs: [terraform-plan]
     
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v4
+#     steps:
+#     # Checkout the repository to the GitHub Actions runner
+#     - name: Checkout
+#       uses: actions/checkout@v4
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+#     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+#     - name: Setup Terraform
+#       uses: hashicorp/setup-terraform@v3
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      id: init
-      run: |
-        terraform init -no-color \
-          -backend-config="resource_group_name=rg-terraform-github-actions-state" \
-          -backend-config="storage_account_name=terraformazurecollection" \
-          -backend-config="container_name=tfstate" \
-          -backend-config="key=terraform.tfstate" 
+#     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+#     - name: Terraform Init
+#       id: init
+#       run: |
+#         terraform init -no-color \
+#           -backend-config="resource_group_name=rg-terraform-github-actions-state" \
+#           -backend-config="storage_account_name=terraformazurecollection" \
+#           -backend-config="container_name=tfstate" \
+#           -backend-config="key=terraform.tfstate" 
 
-    # Download saved plan from artifacts  
-    - name: Download Terraform Plan
-      uses: actions/download-artifact@v4
-      with:
-        name: tfplan
+#     # Download saved plan from artifacts  
+#     - name: Download Terraform Plan
+#       uses: actions/download-artifact@v4
+#       with:
+#         name: tfplan
 
-    # Terraform Apply
-    - name: Terraform Apply
-      run: terraform apply -auto-approve tfplan
+#     # Terraform Apply
+#     - name: Terraform Apply
+#       run: terraform apply -auto-approve tfplan


### PR DESCRIPTION
- Adds basic tf-plan & apply (for push to main) for this collection  --> Fixed Environment Only (Ephemeral environments within Azure for a PR will be addressed later) 
- Collection is setup in Azure Subscription `Terraform CI` in our Azure Observe 
- An App is setup for client-based verification ("Azure AD Service Principal via Client Secret")
- Also adds TF Drift Detection in main (we see this with Application Insights in Azure) 

See https://observe.atlassian.net/browse/OB-29418