### PR TITLE
Update variables.tf - extending cron job delay from 10 mintues to 20

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "observe_domain" {
 variable "timer_resources_func_schedule" {
   type        = string
   description = "Eventhub name to use for resources function"
-  default     = "0 */10 * * * *"
+  default     = "0 */20 * * * *"
 }
 
 variable "timer_vm_metrics_func_schedule" {


### PR DESCRIPTION
Per recommendation from Brian F. , Changing the CRON to run every 20 mintues and not every 10 minutes in the hope that this reduces the ARM resource throttling we are experiencing with Azure presently.