### PR TITLE
Austin/subscription id env var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,6 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
     AZURE_CLIENT_ID                               = azuread_application.observe_app_registration.client_id
     AZURE_CLIENT_SECRET                           = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.observe_password.id})"
     AZURE_CLIENT_LOCATION                         = lower(replace(var.location, " ", ""))
-    AZURE_SUBSCRIPTION_WHITELIST                  = var.azure_subscription_whitelist
     timer_resources_func_schedule                 = var.timer_resources_func_schedule
     timer_vm_metrics_func_schedule                = var.timer_vm_metrics_func_schedule
     EVENTHUB_TRIGGER_FUNCTION_EVENTHUB_NAME       = azurerm_eventhub.observe_eventhub.name

--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,7 @@ resource "azurerm_linux_function_app" "observe_collect_function_app" {
     AZURE_CLIENT_ID                               = azuread_application.observe_app_registration.client_id
     AZURE_CLIENT_SECRET                           = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.observe_password.id})"
     AZURE_CLIENT_LOCATION                         = lower(replace(var.location, " ", ""))
+    AZURE_SUBSCRIPTION_WHITELIST                  = var.azure_subscription_whitelist
     timer_resources_func_schedule                 = var.timer_resources_func_schedule
     timer_vm_metrics_func_schedule                = var.timer_vm_metrics_func_schedule
     EVENTHUB_TRIGGER_FUNCTION_EVENTHUB_NAME       = azurerm_eventhub.observe_eventhub.name

--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ variable "app_settings" {
 
 variable "azure_subscription_whitelist" {
   type = string
-  description = "If you want to filter down the Subscriptions to search within.  This may be necessary if you are reusing a Service Principal that has access to multiple Subscriptions.  This can contain a comma separated list or a single subscription"
+  description = "If you want to filter down the Subscriptions to search within. 'default' will select the subscription where the function is running (blank has the same behavior). A comma separated list will select multiple subscriptions and exclude all others.  'all' is experimental and may cause errors and timeouts.  This should only be chosen at the recommendation of support.  This may be necessary if you are reusing a Service Principal that has access to multiple Subscriptions."
   default = "default"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -147,14 +147,10 @@ variable "app_settings" {
   type = map(string)
   default = {
     FEATURE_FLAGS = ""
+    AZURE_SUBSCRIPTION_WHITELIST                  = "default"
+
   }
   description = "Additional app settings"
-}
-
-variable "azure_subscription_whitelist" {
-  type = string
-  description = "If you want to filter down the Subscriptions to search within. 'default' will select the subscription where the function is running (blank has the same behavior). A comma separated list will select multiple subscriptions and exclude all others.  'all' is experimental and may cause errors and timeouts.  This should only be chosen at the recommendation of support.  This may be necessary if you are reusing a Service Principal that has access to multiple Subscriptions."
-  default = "default"
 }
 
 # required if updating to higher versions of azurerm

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,12 @@ variable "app_settings" {
   description = "Additional app settings"
 }
 
+variable "azure_subscription_whitelist" {
+  type = string
+  description = "If you want to filter down the Subscriptions to search within.  This may be necessary if you are reusing a Service Principal that has access to multiple Subscriptions.  This can contain a comma separated list or a single subscription"
+  default = "default"
+}
+
 # required if updating to higher versions of azurerm
 # variable "subscription_id" {
 #   type = string


### PR DESCRIPTION
Adding the environment variable **AZURE_SUBSCRIPTION_WHITELIST** that will prevent the service principal from inspecting subscriptions where the access may be incorrect.  This would generally only be used when a service principal is not created through automation and is reused